### PR TITLE
warmup directory on project root doesn't exist

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -28,9 +28,11 @@ modify(
       beforeArtifacts = async () => {
         await this.compileTs();
         const target = path.resolve(this.serverless.config.servicePath, opts.warmupDir);
-        if (!fs.existsSync(target)) {
-          fs.symlinkSync(path.resolve(this.originalServicePath, opts.warmupDir), target);
-        }
+        const warmUpDirectory = path.resolve(this.originalServicePath, opts.warmupDir);
+        if(!fs.existsSync(warmUpDirectory))
+          fs.mkdirSync(warmUpDirectory);
+        if (!fs.existsSync(target))
+          fs.symlinkSync(warmUpDirectory, target);
       };
       afterArtifacts = async () => {
         await this.moveArtifacts();


### PR DESCRIPTION
Serverless warmup needs to create a file inside the designated warmup directory.

error on no such file on the directory during build

solution:
if warmup directory doesn't exist. create warmup directory to project root
serverless will create an index file inside warmup directory
wamup bridge linked/soft copy the warmup directory to the .build directory

@suguru03 please review this PR if you agreed. thanks!